### PR TITLE
refactor: Replace HOME env var with os.UserHomeDir()

### DIFF
--- a/cmd/z.go
+++ b/cmd/z.go
@@ -19,7 +19,11 @@ import (
 func main() {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 
-	configPath := path.Join(os.Getenv("HOME"), ".config/z.yml")
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not determine user home directory")
+	}
+	configPath := path.Join(homeDir, ".config/z.yml")
 	configData, readErr := os.ReadFile(configPath)
 	if readErr != nil {
 		if os.IsNotExist(readErr) {
@@ -89,7 +93,7 @@ Configuration is read from ~/.config/z.yml which defines your Ks (knowledge base
 	}
 	parser.SubcommandsOptional = false
 
-	_, err := parser.Parse()
+	_, err = parser.Parse()
 	if err != nil {
 		if flags.WroteHelp(err) {
 			os.Exit(0)

--- a/internal/cli/command_init.go
+++ b/internal/cli/command_init.go
@@ -17,7 +17,11 @@ type InitCommand struct{}
 
 func (_ *InitCommand) Execute(_ []string) error {
 	// Check if config file exists, create boilerplate if not
-	configPath := path.Join(os.Getenv("HOME"), ".config/z.yml")
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("could not determine user home directory: %w", err)
+	}
+	configPath := path.Join(homeDir, ".config/z.yml")
 	if _, err := os.Stat(configPath); errors.Is(err, fs.ErrNotExist) {
 		log.Info().Str("path", configPath).Msg("config file not found, creating boilerplate config")
 
@@ -123,7 +127,11 @@ func createBoilerplateConfig(configPath string) error {
 	}
 
 	// Create boilerplate config with a local 'misc' K
-	miscPath := path.Join(os.Getenv("HOME"), "notes", "misc")
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("could not determine user home directory: %w", err)
+	}
+	miscPath := path.Join(homeDir, "notes", "misc")
 
 	config := cfg.Cfg{
 		Ks: map[string]cfg.K{


### PR DESCRIPTION
Replace all uses of os.Getenv("HOME") with os.UserHomeDir() for bettercross-platform compatibility and proper error handling. os.UserHomeDir()is the idiomatic Go way to get the user's home directory and workscorrectly on Windows, macOS, and Linux.