### PR TITLE
feat: Add configurable color/log-level setting for structured logging

### DIFF
--- a/cmd/z.go
+++ b/cmd/z.go
@@ -17,6 +17,7 @@ import (
 )
 
 func main() {
+	// Initialize logger with colored output by default
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 
 	homeDir, err := os.UserHomeDir()
@@ -44,6 +45,19 @@ func main() {
 					URL:  os.ExpandEnv(k.URL),
 				}
 			}
+
+			// Reconfigure logger based on color setting
+			// If color is not explicitly set (nil), default to true (colored output)
+			// To disable colors, users must explicitly set color: false
+			colorEnabled := true // default
+			if cfg.GlobalCfg.Settings.Color != nil {
+				colorEnabled = *cfg.GlobalCfg.Settings.Color
+			}
+			if !colorEnabled {
+				// Disable colored output
+				log.Logger = log.Output(os.Stderr)
+			}
+
 			log.Debug().Int("ks", len(cfg.GlobalCfg.Ks)).Int("blueprints", len(cfg.GlobalCfg.Blueprints)).Msg("loaded config")
 		}
 	}

--- a/cmd/z.go
+++ b/cmd/z.go
@@ -16,6 +16,28 @@ import (
 	"z/internal/cli"
 )
 
+// parseLogLevel converts a log level string to a zerolog.Level
+func parseLogLevel(levelStr string) zerolog.Level {
+	switch strings.ToLower(levelStr) {
+	case "trace":
+		return zerolog.TraceLevel
+	case "debug":
+		return zerolog.DebugLevel
+	case "info":
+		return zerolog.InfoLevel
+	case "warn", "warning":
+		return zerolog.WarnLevel
+	case "error":
+		return zerolog.ErrorLevel
+	case "fatal":
+		return zerolog.FatalLevel
+	case "panic":
+		return zerolog.PanicLevel
+	default:
+		return zerolog.InfoLevel // default to info
+	}
+}
+
 func main() {
 	// Initialize logger with colored output by default
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
@@ -46,7 +68,16 @@ func main() {
 				}
 			}
 
-			// Reconfigure logger based on color setting
+			// Reconfigure logger based on settings
+
+			// Set log level (default: info)
+			logLevel := zerolog.InfoLevel
+			if cfg.GlobalCfg.Settings.Level != "" {
+				logLevel = parseLogLevel(cfg.GlobalCfg.Settings.Level)
+			}
+			zerolog.SetGlobalLevel(logLevel)
+
+			// Set color output
 			// If color is not explicitly set (nil), default to true (colored output)
 			// To disable colors, users must explicitly set color: false
 			colorEnabled := true // default

--- a/cmd/z.go
+++ b/cmd/z.go
@@ -72,8 +72,8 @@ func main() {
 
 			// Set log level (default: info)
 			logLevel := zerolog.InfoLevel
-			if cfg.GlobalCfg.Settings.Level != "" {
-				logLevel = parseLogLevel(cfg.GlobalCfg.Settings.Level)
+			if cfg.GlobalCfg.Settings.VerbosityLevel != "" {
+				logLevel = parseLogLevel(cfg.GlobalCfg.Settings.VerbosityLevel)
 			}
 			zerolog.SetGlobalLevel(logLevel)
 

--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -13,7 +13,8 @@ type Cfg struct {
 
 // Settings contains application-wide settings.
 type Settings struct {
-	Color *bool `yaml:"color"` // Enable colored output in logs (default: true if nil)
+	Color *bool  `yaml:"color"` // Enable colored output in logs (default: true if nil)
+	Level string `yaml:"level"` // Log level: trace, debug, info, warn, error, fatal, panic (default: info)
 }
 
 // A K is a single 'Kasten', a directory of Zs (files).

--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -13,8 +13,8 @@ type Cfg struct {
 
 // Settings contains application-wide settings.
 type Settings struct {
-	Color *bool  `yaml:"color"` // Enable colored output in logs (default: true if nil)
-	Level string `yaml:"level"` // Log level: trace, debug, info, warn, error, fatal, panic (default: info)
+	Color          *bool  `yaml:"color"`           // Enable colored output in logs (default: true if nil)
+	VerbosityLevel string `yaml:"verbosity-level"` // Log level: trace, debug, info, warn, error, fatal, panic (default: info)
 }
 
 // A K is a single 'Kasten', a directory of Zs (files).

--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -6,8 +6,14 @@ var GlobalCfg Cfg
 
 // Cfg is the top level config.
 type Cfg struct {
+	Settings   Settings             `yaml:"settings"`
 	Ks         map[string]K         `yaml:"Ks"`
 	Blueprints map[string]Blueprint `yaml:"blueprints"`
+}
+
+// Settings contains application-wide settings.
+type Settings struct {
+	Color *bool `yaml:"color"` // Enable colored output in logs (default: true if nil)
 }
 
 // A K is a single 'Kasten', a directory of Zs (files).

--- a/internal/cli/command_init.go
+++ b/internal/cli/command_init.go
@@ -137,6 +137,7 @@ func createBoilerplateConfig(configPath string) error {
 	config := cfg.Cfg{
 		Settings: cfg.Settings{
 			Color: &colorEnabled, // Enable colored output by default
+			Level: "info",        // Default log level
 		},
 		Ks: map[string]cfg.K{
 			"misc": {
@@ -170,6 +171,7 @@ func createBoilerplateConfig(configPath string) error {
 #
 # Settings are application-wide settings:
 #   color: Enable colored output in logs (default: true, set to false to disable)
+#   level: Log verbosity level - trace, debug, info, warn, error, fatal, panic (default: info)
 #
 # Ks are knowledge bases - directories containing your notes
 # Each K can be:

--- a/internal/cli/command_init.go
+++ b/internal/cli/command_init.go
@@ -133,7 +133,11 @@ func createBoilerplateConfig(configPath string) error {
 	}
 	miscPath := path.Join(homeDir, "notes", "misc")
 
+	colorEnabled := true
 	config := cfg.Cfg{
+		Settings: cfg.Settings{
+			Color: &colorEnabled, // Enable colored output by default
+		},
 		Ks: map[string]cfg.K{
 			"misc": {
 				Path: miscPath,
@@ -163,6 +167,9 @@ func createBoilerplateConfig(configPath string) error {
 
 	// Add a helpful comment at the top
 	commentedYAML := `# z configuration file
+#
+# Settings are application-wide settings:
+#   color: Enable colored output in logs (default: true, set to false to disable)
 #
 # Ks are knowledge bases - directories containing your notes
 # Each K can be:

--- a/internal/cli/command_init.go
+++ b/internal/cli/command_init.go
@@ -136,8 +136,8 @@ func createBoilerplateConfig(configPath string) error {
 	colorEnabled := true
 	config := cfg.Cfg{
 		Settings: cfg.Settings{
-			Color: &colorEnabled, // Enable colored output by default
-			Level: "info",        // Default log level
+			Color:          &colorEnabled, // Enable colored output by default
+			VerbosityLevel: "info",        // Default log level
 		},
 		Ks: map[string]cfg.K{
 			"misc": {
@@ -171,7 +171,7 @@ func createBoilerplateConfig(configPath string) error {
 #
 # Settings are application-wide settings:
 #   color: Enable colored output in logs (default: true, set to false to disable)
-#   level: Log verbosity level - trace, debug, info, warn, error, fatal, panic (default: info)
+#   verbosity-level: Log verbosity level - trace, debug, info, warn, error, fatal, panic (default: info)
 #
 # Ks are knowledge bases - directories containing your notes
 # Each K can be:


### PR DESCRIPTION
Add a 'settings' block to the configuration file with a 'color' option that controls whether log output uses colored (ConsoleWriter) or plain JSON format.

Changes:
- Add Settings struct with Color field (pointer to bool) to cfg.Cfg
- Update logger initialization to respect color setting
- Default to colored output when setting is not specified (nil)
- Update boilerplate config generation to include settings block
- Add documentation comments for the new setting

The default behavior (when color is not specified) is to use colored output for backwards compatibility. Users can explicitly set 'color: false' to disable colors and get plain JSON log output.