### PR TITLE
Add linting to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Run golangci-lint
       run: |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+        go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.5.0
         golangci-lint run ./...
 
     - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
     - name: Run go vet
       run: go vet ./...
 
+    - name: Run golangci-lint
+      run: |
+        go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+        golangci-lint run ./...
+
     - name: Run tests
       run: go test -v -race ./...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,9 @@ jobs:
       run: go vet ./...
 
     - name: Run golangci-lint
-      run: |
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.5.0
-        golangci-lint run ./...
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: v2.5.0
 
     - name: Run tests
       run: go test -v -race ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
 
     - name: Run golangci-lint
       run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
         go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
         golangci-lint run ./...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       run: go vet ./...
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v7
       with:
         version: v2.5.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
     - name: Run go vet
       run: go vet ./...
 
+    - name: Configure Git for golangci-lint
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v7
       with:

--- a/internal/cli/command_create.go
+++ b/internal/cli/command_create.go
@@ -19,7 +19,7 @@ import (
 
 type CreateCommand struct{}
 
-func (_ *CreateCommand) Execute(args []string) error {
+func (*CreateCommand) Execute(args []string) error {
 	if len(args) < 2 {
 		return fmt.Errorf("too few arguments: expected 'z create <K> <name> [blueprint]'\n  K:         ID of the knowledge base (K) to create in\n  name:      name for the new note/file\n  blueprint: (optional) blueprint to use for the note")
 	} else if len(args) > 3 {
@@ -163,8 +163,8 @@ func (_ *CreateCommand) Execute(args []string) error {
 	for file := range filesWithContent {
 		if path.IsAbs(file) {
 			return fmt.Errorf(
-				"This resolved path (%s) appears absolute."+
-					"Use paths relative to subdir instead (or to K, if desired and only single file).",
+				"this resolved path (%s) appears absolute."+
+					"Use paths relative to subdir instead (or to K, if desired and only single file)",
 				file,
 			)
 		}

--- a/internal/cli/command_init.go
+++ b/internal/cli/command_init.go
@@ -15,7 +15,7 @@ import (
 
 type InitCommand struct{}
 
-func (_ *InitCommand) Execute(_ []string) error {
+func (*InitCommand) Execute(_ []string) error {
 	// Check if config file exists, create boilerplate if not
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/cli/command_open.go
+++ b/internal/cli/command_open.go
@@ -123,10 +123,10 @@ func (c *OpenCommand) Execute(args []string) error {
 				if err != nil {
 					return nil, fmt.Errorf("on unknown extension '%s', could not get user input (%s)", ext, err.Error())
 				}
-				switch {
-				case response == "" || response == "y" || response == "Y" || response == "yes":
+				switch response {
+				case "", "y", "Y", "yes":
 					return exec.Command("nvim", fullPath), nil
-				case response == "n" || response == "N" || response == "no":
+				case "n", "N", "no":
 					return nil, fmt.Errorf("user rejected suggested editor for unkonwn extensions '%s'", ext)
 				default:
 					return nil, fmt.Errorf("unknown file extension '%s' and unknown response '%s' to prompt", ext, response)
@@ -161,7 +161,7 @@ func (c *OpenCommand) Execute(args []string) error {
 		}
 
 	default:
-		return fmt.Errorf("Unknown Z-Type '%s'", zType)
+		return fmt.Errorf("unknown Z-Type '%s'", zType)
 	}
 
 	return nil

--- a/internal/cli/command_open.go
+++ b/internal/cli/command_open.go
@@ -127,7 +127,7 @@ func (c *OpenCommand) Execute(args []string) error {
 				case "", "y", "Y", "yes":
 					return exec.Command("nvim", fullPath), nil
 				case "n", "N", "no":
-					return nil, fmt.Errorf("user rejected suggested editor for unkonwn extensions '%s'", ext)
+					return nil, fmt.Errorf("user rejected suggested editor for unknown extensions '%s'", ext)
 				default:
 					return nil, fmt.Errorf("unknown file extension '%s' and unknown response '%s' to prompt", ext, response)
 				}

--- a/internal/cli/command_open.go
+++ b/internal/cli/command_open.go
@@ -52,11 +52,16 @@ func (c *OpenCommand) Execute(args []string) error {
 		if z.View != "" {
 			log.Info().Str("command", z.View).Msg("running view command")
 			viewCmd := exec.Command("bash", "-c", fmt.Sprintf("cd '%s' ; %s", fullPath, z.View))
-			viewCmd.Start()
-			defer func() {
-				log.Info().Msg("terminating view command on exit")
-				viewCmd.Process.Kill()
-			}()
+			if err := viewCmd.Start(); err != nil {
+				log.Warn().Err(err).Msg("failed to start view command")
+			} else {
+				defer func() {
+					log.Info().Msg("terminating view command on exit")
+					if err := viewCmd.Process.Kill(); err != nil {
+						log.Warn().Err(err).Msg("failed to kill view command process")
+					}
+				}()
+			}
 		}
 		// NOTE(ja-he):
 		//  Neovim, a common open command for me, does some weird stuff on cleanup

--- a/internal/cli/command_preview.go
+++ b/internal/cli/command_preview.go
@@ -119,7 +119,7 @@ func (c *PreviewCommand) Execute(args []string) error {
 		}
 
 	default:
-		return fmt.Errorf("Unknown Z-Type '%s'", zType)
+		return fmt.Errorf("unknown Z-Type '%s'", zType)
 
 	}
 

--- a/internal/cli/command_version.go
+++ b/internal/cli/command_version.go
@@ -10,10 +10,10 @@ import (
 type VersionCommand struct{}
 
 func (_ *VersionCommand) Execute(_ []string) error {
-	rand.Seed(time.Now().UnixMilli())
+	rng := rand.New(rand.NewSource(time.Now().UnixMilli()))
 	randomAnimal := func() uint32 {
 		lb, ub := uint32(0x1f400), uint32(0x1f43c)
-		return (rand.Uint32() % (ub - lb)) + lb
+		return (rng.Uint32() % (ub - lb)) + lb
 	}
 	fmt.Printf(
 		"v(%c).(%c).(%c)\n",

--- a/internal/cli/command_version.go
+++ b/internal/cli/command_version.go
@@ -9,7 +9,7 @@ import (
 
 type VersionCommand struct{}
 
-func (_ *VersionCommand) Execute(_ []string) error {
+func (*VersionCommand) Execute(_ []string) error {
 	rng := rand.New(rand.NewSource(time.Now().UnixMilli()))
 	randomAnimal := func() uint32 {
 		lb, ub := uint32(0x1f400), uint32(0x1f43c)


### PR DESCRIPTION
- Add golangci-lint step to CI workflow for comprehensive linting
- Fix errcheck issues in command_open.go by properly handling error returns from viewCmd.Start() and viewCmd.Process.Kill()
- Replace deprecated rand.Seed() with rand.New(rand.NewSource()) in command_version.go

All linting issues identified by golangci-lint have been resolved.