### PR TITLE
Separate CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [ main, master ]
 
 jobs:
-  test:
-    name: Test & Build
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     container: golang:1.24
 
@@ -30,9 +30,6 @@ jobs:
           exit 1
         fi
 
-    - name: Run go vet
-      run: go vet ./...
-
     - name: Configure Git for golangci-lint
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
@@ -41,8 +38,56 @@ jobs:
       with:
         version: v2.5.0
 
+  vet:
+    name: Vet
+    runs-on: ubuntu-latest
+    container: golang:1.24
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Verify dependencies
+      run: go mod verify
+
+    - name: Run go vet
+      run: go vet ./...
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    container: golang:1.24
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Verify dependencies
+      run: go mod verify
+
     - name: Run tests
       run: go test -v -race ./...
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    container: golang:1.24
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Verify dependencies
+      run: go mod verify
 
     - name: Build
       run: go build -v ./cmd/z.go


### PR DESCRIPTION
Splits the monolithic 'Test & Build' job into four independent jobs:
- Lint: Code formatting (gofmt) and golangci-lint
- Vet: Run go vet
- Test: Run tests with race detection
- Build: Build binaries for multiple architectures

This provides better visibility into which specific check fails and allows jobs to run in parallel for faster feedback.