### PR TITLE
Allow correcting incorrect remote in existing directory via new flag on 'init'

### DIFF
--- a/internal/cli/command_init.go
+++ b/internal/cli/command_init.go
@@ -190,7 +190,7 @@ func (c *InitCommand) Execute(_ []string) error {
 							if err != nil {
 								log.Warn().Str("K", id).Err(err).Msg("could not check for unpushed commits")
 							} else if hasUnpushed {
-								log.Warn().Str("K", id).Msg("WARNING: repository has unpushed commits, but updating remote URL anyway")
+								log.Warn().Str("K", id).Msg("repository has unpushed commits, but updating remote URL anyway")
 							}
 
 							// Update the remote URL

--- a/internal/cli/command_init_test.go
+++ b/internal/cli/command_init_test.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestNormalizeGitURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "SSH URL unchanged",
+			input:    "git@github.com:user/repo.git",
+			expected: "git@github.com:user/repo.git",
+		},
+		{
+			name:     "HTTPS URL without credentials",
+			input:    "https://github.com/user/repo.git",
+			expected: "https://github.com/user/repo.git",
+		},
+		{
+			name:     "HTTPS URL with credentials removed",
+			input:    "https://username:password@github.com/user/repo.git",
+			expected: "https://github.com/user/repo.git",
+		},
+		{
+			name:     "HTTPS URL with username only removed",
+			input:    "https://username@github.com/user/repo.git",
+			expected: "https://github.com/user/repo.git",
+		},
+		{
+			name:     "git protocol URL unchanged",
+			input:    "git://github.com/user/repo.git",
+			expected: "git://github.com/user/repo.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := normalizeGitURL(tt.input)
+			if err != nil {
+				t.Errorf("normalizeGitURL() error = %v", err)
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("normalizeGitURL() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestUrlsMatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		url1   string
+		url2   string
+		expect bool
+	}{
+		{
+			name:   "identical HTTPS URLs",
+			url1:   "https://github.com/user/repo.git",
+			url2:   "https://github.com/user/repo.git",
+			expect: true,
+		},
+		{
+			name:   "HTTPS URLs with and without credentials",
+			url1:   "https://token@github.com/user/repo.git",
+			url2:   "https://github.com/user/repo.git",
+			expect: true,
+		},
+		{
+			name:   "HTTPS URLs with different credentials",
+			url1:   "https://token1@github.com/user/repo.git",
+			url2:   "https://token2@github.com/user/repo.git",
+			expect: true,
+		},
+		{
+			name:   "identical SSH URLs",
+			url1:   "git@github.com:user/repo.git",
+			url2:   "git@github.com:user/repo.git",
+			expect: true,
+		},
+		{
+			name:   "different repositories",
+			url1:   "https://github.com/user/repo1.git",
+			url2:   "https://github.com/user/repo2.git",
+			expect: false,
+		},
+		{
+			name:   "SSH vs HTTPS same repo",
+			url1:   "git@github.com:user/repo.git",
+			url2:   "https://github.com/user/repo.git",
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := urlsMatch(tt.url1, tt.url2)
+			if result != tt.expect {
+				t.Errorf("urlsMatch(%v, %v) = %v, want %v", tt.url1, tt.url2, result, tt.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This flag enables checking and updating remote URLs for existing repositories. When used, the init command will:

- Check each repository's current remote URL
- Compare it with the configured URL (ignoring credentials in HTTPS URLs)
- Update the remote URL if there's a mismatch
- Warn if there are unpushed commits before updating

This is useful when remote URLs change or when repositories have been set up with incorrect URLs.

The implementation includes:
- URL normalization that strips credentials from HTTPS URLs for comparison
- Support for both SSH and HTTPS URL formats
- Detection of unpushed commits with appropriate warnings
- Comprehensive test coverage for URL normalization